### PR TITLE
fix: transaction issue with spring 3.3 by downgrading micrometer version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.12</version>
-<!--        <version>3.3.5</version>-->
+        <!-- <version>3.2.12</version> -->
+        <version>3.3.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.generalnitin</groupId>
@@ -17,6 +17,7 @@
 
     <properties>
         <java.version>17</java.version>
+        <micrometer.version>1.12.13</micrometer.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Description:
Upon checking the logs generated by jcabi-maven-plugin:
```
Mon Jan 13 21:16:31 IST 2025
io/micrometer/observation/aop/ObservedAspect.java [error] Invalid pointcut '@within(io.micrometer.observation.annotation.Observed) and not @annotation(io.micrometer.observation.annotation.Observed)': org.aspectj.weaver.patterns.ParserException: unexpected pointcut element: and@55:57 at position 55
	
<Unknown> [warning] Found @DeclareAnnotation while current release does not support it (see 'org.aspectj.weaver.bcel.AtAjAttributes')
	
io/micrometer/observation/aop/ObservedAspect.java [error] Invalid pointcut '@within(io.micrometer.observation.annotation.Observed) and not @annotation(io.micrometer.observation.annotation.Observed)': org.aspectj.weaver.patterns.ParserException: unexpected pointcut element: and@55:57 at position 55
	
<Unknown> [warning] Found @DeclareAnnotation while current release does not support it (see 'org.aspectj.weaver.bcel.AtAjAttributes')
	
```
I saw 2 errors, because of micrometer library, so I tried downgrading it to Spring Boot 3.2's version i.e. `1.12.13` from `1.13.6`, and it works.

### Not the Best Soultion but fixes the issue and at least the application is in running state