### PR TITLE
Migrate to AspectJ Maven, fix Spring transactions and Micrometer pointcut error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <micrometer.version>1.12.13</micrometer.version>
+        <!-- <micrometer.version>1.12.13</micrometer.version> -->
     </properties>
 
     <dependencies>
@@ -42,6 +42,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjrt</artifactId>
+            <version>${aspectj.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -49,53 +55,58 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/unwoven-classes</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
-            <!-- binary weaving of aspects on the classpath. -->
             <plugin>
-                <groupId>com.jcabi</groupId>
-                <artifactId>jcabi-maven-plugin</artifactId>
-                <version>0.17.0</version>
+                <groupId>dev.aspectj</groupId>
+                <artifactId>aspectj-maven-plugin</artifactId>
+                <version>1.14</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
-                    <disableCopy>true</disableCopy>
+                    <verbose>true</verbose>
+                    <privateScope>true</privateScope>
+                    <complianceLevel>17</complianceLevel>
+                    <weaveDirectories>
+                        <weaveDirectory>${project.build.directory}/unwoven-classes</weaveDirectory>
+                    </weaveDirectories>
                 </configuration>
                 <executions>
-
-                    <!-- weave main classes. -->
                     <execution>
                         <id>weave-main</id>
                         <phase>process-classes</phase>
                         <configuration>
-                            <classesDirectory>${project.build.outputDirectory}</classesDirectory>
-                            <log>${project.build.directory}/jcabi-ajc-main.log</log>
+                            <showWeaveInfo>true</showWeaveInfo>
+                            <verbose>true</verbose>
                         </configuration>
                         <goals>
-                            <goal>ajc</goal>
+                            <goal>compile</goal>
                         </goals>
                     </execution>
-
-                    <!-- weave test classes. -->
                     <execution>
                         <id>weave-test</id>
                         <phase>process-test-classes</phase>
-                        <configuration>
-                            <classesDirectory>${project.build.testOutputDirectory}</classesDirectory>
-                            <log>${project.build.directory}/jcabi-ajc-tests.log</log>
-                        </configuration>
                         <goals>
-                            <goal>ajc</goal>
+                            <goal>test-compile</goal>
                         </goals>
                     </execution>
+<!--                    <execution>-->
+<!--                        <id>weave-report</id>-->
+<!--                        <phase>process-classes</phase>-->
+<!--                        <configuration>-->
+<!--                            <verbose>true</verbose>-->
+<!--                        </configuration>-->
+<!--                        <goals>-->
+<!--                            <goal>aspectj-report</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
                 </executions>
-
                 <dependencies>
-                    <dependency>
-                        <groupId>org.aspectj</groupId>
-                        <artifactId>aspectjrt</artifactId>
-                        <version>${aspectj.version}</version>
-                    </dependency>
                     <dependency>
                         <groupId>org.aspectj</groupId>
                         <artifactId>aspectjtools</artifactId>
@@ -105,5 +116,24 @@
             </plugin>
         </plugins>
     </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>dev.aspectj</groupId>
+                <artifactId>aspectj-maven-plugin</artifactId>
+                <version>1.14</version>
+                <configuration>
+                </configuration>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>aspectj-report</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <!-- <micrometer.version>1.12.13</micrometer.version> -->
+        <micrometer.version>1.13.6</micrometer.version>
     </properties>
 
     <dependencies>
@@ -48,6 +48,32 @@
             <artifactId>aspectjrt</artifactId>
             <version>${aspectj.version}</version>
         </dependency>
+
+        <!-- Needed by spring-aspects -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context-support</artifactId>
+            <version>${spring-framework.version}</version>
+        </dependency>
+        <!-- Needed by spring-aspects -->
+        <dependency>
+            <groupId>javax.cache</groupId>
+            <artifactId>cache-api</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+        <!-- Help AspectJ Maven find the library -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-observation</artifactId>
+            <version>${micrometer.version}</version>
+        </dependency>
+        <!-- Needed by micrometer-observation (ObservedAspect, enabling @Observed) -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>context-propagation</artifactId>
+            <version>1.1.2</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -75,6 +101,18 @@
                     <weaveDirectories>
                         <weaveDirectory>${project.build.directory}/unwoven-classes</weaveDirectory>
                     </weaveDirectories>
+                    <weaveDependencies>
+                        <!-- Spring transactions in native AspectJ mode -->
+                        <weaveDependency>
+                            <groupId>org.springframework</groupId>
+                            <artifactId>spring-aspects</artifactId>
+                        </weaveDependency>
+                        <!-- ObservedAspect, enabling @Observed -->
+                        <weaveDependency>
+                            <groupId>io.micrometer</groupId>
+                            <artifactId>micrometer-observation</artifactId>
+                        </weaveDependency>
+                    </weaveDependencies>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <micrometer.version>1.13.6</micrometer.version>
+        <micrometer.version>1.14.3</micrometer.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/com/generalnitin/springaop/SpringAopApplication.java
+++ b/src/main/java/com/generalnitin/springaop/SpringAopApplication.java
@@ -1,15 +1,29 @@
 package com.generalnitin.springaop;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.AdviceMode;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import javax.sql.DataSource;
 
 @SpringBootApplication
 @EnableTransactionManagement(mode = AdviceMode.ASPECTJ)
 public class SpringAopApplication {
 
+    private static final Logger log = LoggerFactory.getLogger(SpringAopApplication.class);
+
     public static void main(String[] args) {
         SpringApplication.run(SpringAopApplication.class, args);
+    }
+
+    @Bean
+    public DataSourceTransactionManager transactionManager(DataSource dataSource) {
+        log.info("init transactionManager");
+        return new DataSourceTransactionManager(dataSource);
     }
 }

--- a/src/main/java/com/generalnitin/springaop/SpringAopApplication.java
+++ b/src/main/java/com/generalnitin/springaop/SpringAopApplication.java
@@ -1,29 +1,23 @@
 package com.generalnitin.springaop;
 
+import com.generalnitin.springaop.services.HomeService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AdviceMode;
-import org.springframework.context.annotation.Bean;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
-
-import javax.sql.DataSource;
 
 @SpringBootApplication
 @EnableTransactionManagement(mode = AdviceMode.ASPECTJ)
 public class SpringAopApplication {
-
     private static final Logger log = LoggerFactory.getLogger(SpringAopApplication.class);
 
     public static void main(String[] args) {
-        SpringApplication.run(SpringAopApplication.class, args);
-    }
-
-    @Bean
-    public DataSourceTransactionManager transactionManager(DataSource dataSource) {
-        log.info("init transactionManager");
-        return new DataSourceTransactionManager(dataSource);
+        try (ConfigurableApplicationContext context = SpringApplication.run(SpringAopApplication.class, args)) {
+            System.out.println(context.getBean(HomeService.class).sayHello());
+            System.out.println(context.getBean(HomeService.class).testTransaction());
+        }
     }
 }

--- a/src/main/java/com/generalnitin/springaop/aspects/LogAspect.java
+++ b/src/main/java/com/generalnitin/springaop/aspects/LogAspect.java
@@ -14,7 +14,8 @@ import java.util.concurrent.TimeUnit;
 @Component
 public class LogAspect {
 
-    @Around("@annotation(CustomAnnotation)")
+    // Add 'execution(* *(..))' to avoid capturing native AspectJ 'call' pointcuts
+    @Around("@annotation(CustomAnnotation) && execution(* *(..))")
     public Object log(ProceedingJoinPoint joinPoint) throws Throwable {
         Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
         CustomAnnotation execTime = method.getAnnotation(CustomAnnotation.class);

--- a/src/main/java/com/generalnitin/springaop/services/HomeService.java
+++ b/src/main/java/com/generalnitin/springaop/services/HomeService.java
@@ -2,13 +2,13 @@ package com.generalnitin.springaop.services;
 
 import com.generalnitin.springaop.aspects.CustomAnnotation;
 
+import io.micrometer.observation.annotation.Observed;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class HomeService {
-
     private final SupportService supportService;
 
     public HomeService(SupportService supportService) {
@@ -20,8 +20,8 @@ public class HomeService {
         return "Hello World!";
     }
 
-
-    @Transactional(transactionManager = "transactionManager", propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.REQUIRED)
+    @Observed
     public String testTransaction() {
         supportService.testSupportTransaction();
         return "Success";

--- a/src/main/java/com/generalnitin/springaop/services/HomeService.java
+++ b/src/main/java/com/generalnitin/springaop/services/HomeService.java
@@ -21,7 +21,7 @@ public class HomeService {
     }
 
 
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(transactionManager = "transactionManager", propagation = Propagation.REQUIRED)
     public String testTransaction() {
         supportService.testSupportTransaction();
         return "Success";

--- a/src/main/java/com/generalnitin/springaop/services/SupportService.java
+++ b/src/main/java/com/generalnitin/springaop/services/SupportService.java
@@ -13,12 +13,12 @@ public class SupportService {
     @PersistenceContext
     EntityManager entityManager;
 
-    @Transactional(propagation = Propagation.MANDATORY)
+    @Transactional(transactionManager = "transactionManager", propagation = Propagation.MANDATORY)
     public void testSupportTransaction() {
         Home home = new Home();
         home.setName("Test Data");
         entityManager.persist(home); // fails here in Spring 3.3 with msg: jakarta.persistence.TransactionRequiredException: No EntityManager with actual transaction available for current thread - cannot reliably process 'persist' call
         entityManager.flush();
-        entityManager.refresh(home);
+        entityManager.refresh(home); // unnecessary, but just to test
     }
 }

--- a/src/main/java/com/generalnitin/springaop/services/SupportService.java
+++ b/src/main/java/com/generalnitin/springaop/services/SupportService.java
@@ -13,7 +13,7 @@ public class SupportService {
     @PersistenceContext
     EntityManager entityManager;
 
-    @Transactional(transactionManager = "transactionManager", propagation = Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.MANDATORY)
     public void testSupportTransaction() {
         Home home = new Home();
         home.setName("Test Data");

--- a/src/test/java/com/generalnitin/springaop/SpringAopApplicationTests.java
+++ b/src/test/java/com/generalnitin/springaop/SpringAopApplicationTests.java
@@ -5,9 +5,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class SpringAopApplicationTests {
-
     @Test
-    void contextLoads() {
+    void test() {
+        SpringAopApplication.main(new String[0]);
     }
-
 }


### PR DESCRIPTION
* Fix Spring native AspectJ transactions by using `spring-aspects` as an AspectJ Maven weave dependency.
* Reproduce the Micrometer "invalid pointcut" problem. Fix it by upgrading Micrometer version. The problem was fixed as part of https://github.com/micrometer-metrics/micrometer/issues/1149,
see my own comment https://github.com/micrometer-metrics/micrometer/issues/1149#issuecomment-2102207826 suggesting the fix.